### PR TITLE
Correcting addon field name links

### DIFF
--- a/src/Addon/Table/AddonTableColumns.php
+++ b/src/Addon/Table/AddonTableColumns.php
@@ -24,7 +24,7 @@ class AddonTableColumns implements SelfHandling
             [
                 [
                     'heading' => 'module::field.name.name',
-                    'wrapper' => '<a href="/admin/addons/details/{value.addon}" data-toggle="modal" data-target="#modal">{value.title}</a>',
+                    'wrapper' => '<a href="' . url("admin/addons/details/{value.addon}") .'" data-toggle="modal" data-target="#modal">{value.title}</a>',
                     'value'   => [
                         'title' => 'entry.title',
                         'addon' => 'entry.namespace'


### PR DESCRIPTION
Surrounding href in `url()` function so that field name links in the addon tables (which open in a modal) point to the right place. Previously I was getting a 404 error in the modal as they were pointing to `http://localhost/admin/addons/details/{value.addon}` as opposed to `http://localhost/appname/admin/addons/details/{value.addon}`.
