### PR TITLE
Cleanup tests, mark as skipped

### DIFF
--- a/tests/Unit/Addon/AddonCollectionTest.php
+++ b/tests/Unit/Addon/AddonCollectionTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Addon;
 class AddonCollectionTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Addon/AddonCriteriaTest.php
+++ b/tests/Unit/Addon/AddonCriteriaTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonCriteriaTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/AddonModelTest.php
+++ b/tests/Unit/Addon/AddonModelTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Addon;
 class AddonModelTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Addon/AddonObserverTest.php
+++ b/tests/Unit/Addon/AddonObserverTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonObserverTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/AddonPresenterTest.php
+++ b/tests/Unit/Addon/AddonPresenterTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonPresenterTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/AddonRepositoryTest.php
+++ b/tests/Unit/Addon/AddonRepositoryTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Addon;
 class AddonRepositoryTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Addon/AddonRouterTest.php
+++ b/tests/Unit/Addon/AddonRouterTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonRouterTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/AddonSeederTest.php
+++ b/tests/Unit/Addon/AddonSeederTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonSeederTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/Form/AddonFormBuilderTest.php
+++ b/tests/Unit/Addon/Form/AddonFormBuilderTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Addon;
-
-class AddonFormBuilderTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Addon/Table/AddonTableBuilderTest.php
+++ b/tests/Unit/Addon/Table/AddonTableBuilderTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Addon;
 class AddonTableBuilderTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/Command/DownloadRepositoryTest.php
+++ b/tests/Unit/Repository/Command/DownloadRepositoryTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class DownloadRepositoryTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/Form/RepositoryFormBuilderTest.php
+++ b/tests/Unit/Repository/Form/RepositoryFormBuilderTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryFormBuilderTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryCollectionTest.php
+++ b/tests/Unit/Repository/RepositoryCollectionTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryCollectionTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryCriteriaTest.php
+++ b/tests/Unit/Repository/RepositoryCriteriaTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Repository;
-
-class RepositoryCriteriaTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Repository/RepositoryManagerTest.php
+++ b/tests/Unit/Repository/RepositoryManagerTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryManagerTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryModelTest.php
+++ b/tests/Unit/Repository/RepositoryModelTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryModelTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryObserverTest.php
+++ b/tests/Unit/Repository/RepositoryObserverTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryObserverTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryPresenterTest.php
+++ b/tests/Unit/Repository/RepositoryPresenterTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Repository;
-
-class RepositoryPresenterTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Repository/RepositoryRepositoryTest.php
+++ b/tests/Unit/Repository/RepositoryRepositoryTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryRepositoryTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/RepositoryRouterTest.php
+++ b/tests/Unit/Repository/RepositoryRouterTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Anomaly\AddonsModule\Test\Unit\Repository;
-
-class RepositoryRouterTest extends \TestCase
-{
-
-}

--- a/tests/Unit/Repository/RepositorySeederTest.php
+++ b/tests/Unit/Repository/RepositorySeederTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositorySeederTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }

--- a/tests/Unit/Repository/Table/RepositoryTableBuilderTest.php
+++ b/tests/Unit/Repository/Table/RepositoryTableBuilderTest.php
@@ -5,4 +5,9 @@ namespace Anomaly\AddonsModule\Test\Unit\Repository;
 class RepositoryTableBuilderTest extends \TestCase
 {
 
+    public function testUnit()
+    {
+        $this->markTestSkipped();
+    }
+
 }


### PR DESCRIPTION
* Removed tests with nothing to tests (e.g. `AddonObserverTest` because no `AddonObserver` exists)
* Mark the remain as Skipped (empty test will break the phpunit and CI pipe)