### PR TITLE
Fixed assets dir

### DIFF
--- a/src/Console/Sync.php
+++ b/src/Console/Sync.php
@@ -48,6 +48,10 @@ class Sync extends Command
 
         $manifest = [];
 
+        if (! is_dir($application->getAssetsPath())) {
+            mkdir($application->getAssetsPath());
+        }
+
         $log = $application->getAssetsPath('process.log');
 
         file_put_contents($log, '');


### PR DESCRIPTION
Create the assets directory in case it doesn't exists yet (quite uncommon, but basically if you `php artisan refresh` just after `install` it will fail)